### PR TITLE
fix jshell not starting when classpath directory does not exist

### DIFF
--- a/src/main/groovy/net/java/openjdk/shinyafox/jshell/gradle/plugin/JShellGradlePlugin.groovy
+++ b/src/main/groovy/net/java/openjdk/shinyafox/jshell/gradle/plugin/JShellGradlePlugin.groovy
@@ -19,7 +19,7 @@ class JShellGradlePlugin implements Plugin<Project> {
         .doLast {
             def path
             project.tasks.withType(JavaCompile) {
-                path = classpath.asPath
+                path = classpath.findAll{ it.exists() }.join(':')
             }
 
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader()) // promote class loader


### PR DESCRIPTION
I noticed that the plugin was adding `src/main/resources` folder to jshell's classpath. 

Apparently jshell doesn't start if you append non-existing directories to the classpath. The project I was working on didn't really have a `src/main/resources` folder.

This simple change seems to fix it. 

Questions:
* Do you have any ideas on how can I test this?
* Do you want me to open an issue first, stating the problem?

